### PR TITLE
Refactoring Pointer

### DIFF
--- a/O2DESNet.UnitTests/Core/Pointer_Tests.cs
+++ b/O2DESNet.UnitTests/Core/Pointer_Tests.cs
@@ -56,15 +56,15 @@ namespace O2DESNet.UnitTests.Core
         }
 
         [Test]
-        public void PointerA_Times_PointerB_Deivide_By_PointerA_Should_Return_PointerB()
+        public void PointerA_Times_PointerB_Deivide_By_PointerB_Should_Return_PointerA()
         {
-            Pointer pointerA= new Pointer(1, 2, 45, true);
-            Pointer pointerB = new Pointer(1, 2, 45, true);
+            Pointer pointerA = new Pointer(1, 2, 45, true);
+            Pointer pointerB = new Pointer(2, 3, 45, true);
 
             var mulPointer = pointerA * pointerB;
-            var divpointer = mulPointer / pointerA;
+            var divpointer = mulPointer / pointerB;
 
-            Assert.AreEqual(divpointer, pointerB);
+            Assert.AreEqual(divpointer, pointerA);
         }
 
         [Test]

--- a/O2DESNet.UnitTests/Core/Pointer_Tests.cs
+++ b/O2DESNet.UnitTests/Core/Pointer_Tests.cs
@@ -1,0 +1,141 @@
+﻿using NUnit.Framework;
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace O2DESNet.UnitTests.Core
+{
+    public class Pointer_Tests
+    {
+        [Test]
+        public void Creating_Empty_Pointer()
+        {
+            var pointer = Pointer.Empty;
+
+            Assert.AreEqual(pointer.X, 0d);
+            Assert.AreEqual(pointer.Y, 0d);
+            Assert.AreEqual(pointer.Angle, 0d);
+            Assert.AreEqual(pointer.Flipped, false);
+            Assert.AreEqual(pointer.IsEmpty, true);
+        }
+
+        [Test]
+        public void Created_Pointer_Should_Not_Empty()
+        {
+            Pointer pointer = new Pointer(1, 2, 45, true);
+            Assert.AreEqual(pointer.IsEmpty, false);
+        }
+
+        [Test]
+        public void PointerA_Should_Equal_PointerB()
+        {
+            Pointer pointerA = new Pointer(1, 2, 45, true);
+            Pointer pointerB = new Pointer(1, 2, 45, true);
+            Assert.AreEqual(pointerA, pointerB);
+        }
+
+        [Test]
+        public void PointerA_Should_Not_Equal_PointerB()
+        {
+            Pointer pointerA = new Pointer(1, 2, 45, true);
+            Pointer pointerB = new Pointer(1, 2, 45, false);
+            Assert.AreNotEqual(pointerA, pointerB);
+
+            pointerA = new Pointer(1, 2, 45, true);
+            pointerB = new Pointer(2, 2, 45, true);
+            Assert.AreNotEqual(pointerA, pointerB);
+
+            pointerA = new Pointer(1, 2, 45, true);
+            pointerB = new Pointer(1, 3, 45, true);
+            Assert.AreNotEqual(pointerA, pointerB);
+
+            pointerA = new Pointer(1, 2, 45, true);
+            pointerB = new Pointer(1, 2, 46, true);
+            Assert.AreNotEqual(pointerA, pointerB);
+        }
+
+        [Test]
+        public void PointerA_Times_PointerB_Deivide_By_PointerA_Should_Return_PointerB()
+        {
+            Pointer pointerA= new Pointer(1, 2, 45, true);
+            Pointer pointerB = new Pointer(1, 2, 45, true);
+
+            var mulPointer = pointerA * pointerB;
+            var divpointer = mulPointer / pointerA;
+
+            Assert.AreEqual(divpointer, pointerB);
+        }
+
+        [Test]
+        public void Created_Pointer_Can_Be_Serialized_As_Json_And_Deserialized_Back()
+        {
+            Pointer pointerA = new Pointer(1, 2, 45, true);
+
+            // this option is just to make the json formatting pretty
+            // and able to convert Pointer struct using custom converter
+            var jsonOption = new JsonSerializerOptions { WriteIndented = true };
+            jsonOption.Converters.Add(new PointerJsonConverter());
+
+            // first, serialize Pointer as json string
+            var json = JsonSerializer.Serialize(pointerA, jsonOption);
+            TestContext.WriteLine("Output pointerA as Json");
+            TestContext.WriteLine(json);
+
+            // second, deserialize json string back to pointer
+            var pointerB = JsonSerializer.Deserialize<Pointer>(json, jsonOption);
+
+            // the result should be equal Pointer
+            Assert.AreEqual(pointerA, pointerB);
+        }
+    }
+
+
+    /// <summary>
+    /// This is just a helper class for pointer testing. As pointer is a custom struct value type,
+    /// there is no converter in Json serializer and it require custom converter to convert it.
+    /// </summary>
+    /// <seealso cref="System.Text.Json.Serialization.JsonConverter{O2DESNet.Pointer}" />
+    internal class PointerJsonConverter : JsonConverter<Pointer>
+    {
+        public override Pointer Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+                throw new JsonException("JSON payload expected to start with StartObject token.");
+
+            double X = 0, Y = 0, Angle = 0;
+            bool Flipped = false;
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject) break;
+                if (reader.TokenType == JsonTokenType.PropertyName)
+                {
+                    if (reader.GetString() == nameof(X)) { reader.Read(); X = reader.GetDouble(); continue; }
+                    if (reader.GetString() == nameof(Y)) { reader.Read(); Y = reader.GetDouble(); continue; }
+                    if (reader.GetString() == nameof(Angle)) { reader.Read(); Angle = reader.GetDouble(); continue; }
+                    if (reader.GetString() == nameof(Flipped)) { reader.Read(); Flipped = reader.GetBoolean(); continue; }
+                }
+            }
+
+            return new Pointer(X, Y, Angle, Flipped);
+        }
+
+        public override void Write(Utf8JsonWriter writer, Pointer value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName(nameof(value.X));
+            writer.WriteNumberValue(value.X);
+            writer.WritePropertyName(nameof(value.Y));
+            writer.WriteNumberValue(value.Y);
+            writer.WritePropertyName(nameof(value.Angle));
+            writer.WriteNumberValue(value.Angle);
+            writer.WritePropertyName(nameof(value.Flipped));
+            writer.WriteBooleanValue(value.Flipped);
+            writer.WritePropertyName(nameof(value.IsEmpty));
+            writer.WriteBooleanValue(value.IsEmpty);
+            writer.WriteEndObject();
+            writer.Flush();
+        }
+    }
+}

--- a/O2DESNet/Pointer.cs
+++ b/O2DESNet/Pointer.cs
@@ -1,41 +1,158 @@
 ﻿using System;
+using System.Globalization;
 
 namespace O2DESNet
 {
+    [Serializable]
     public struct Pointer
     {
-        public double X { get; }
-        public double Y { get; }
-        public double Angle { get; }
-        public bool Flipped { get; }
-        public Pointer(double x = 0, double y = 0, double angle = 0, bool flipped = false)
+        /// <summary>
+        /// Empty Pointer
+        /// </summary>
+        public static Pointer Empty => new();
+
+        // This epsilon tolerance number is used for checking
+        // equality which consider 1d = 1.0000000000000001d
+        private const double epsilon = 1E-15d;
+
+        private readonly double x;
+        private readonly double y;
+        private readonly double angle;
+        private readonly bool flipped;
+
+        /// <summary>
+        /// Gets the x.
+        /// </summary>
+        public double X => x;
+
+        /// <summary>
+        /// Gets the y.
+        /// </summary>
+        public double Y => y;
+
+        /// <summary>
+        /// Gets the angle.
+        /// </summary>
+        public double Angle => angle;
+
+        /// <summary>
+        /// Gets a value indicating whether this <see cref="Pointer"/> is flipped.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if flipped; otherwise, <c>false</c>.
+        /// </value>
+        public bool Flipped => flipped;
+
+        /// <summary>
+        /// Gets a value indicating whether this instance is empty.
+        /// Zero tolerance (epsilon) value is 1E-15.
+        /// </summary>
+        public bool IsEmpty => this == Pointer.Empty;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Pointer"/> struct.
+        /// </summary>
+        /// <param name="x">The x.</param>
+        /// <param name="y">The y.</param>
+        /// <param name="angle">The angle.</param>
+        /// <param name="flipped">if set to <c>true</c> [flipped].</param>
+        public Pointer(double x, double y, double angle, bool flipped)
         {
-            X = x;
-            Y = y;
-            Angle = angle;
-            Flipped = flipped;
+            this.x = x;
+            this.y = y;
+            this.angle = angle;
+            this.flipped = flipped;
         }
 
         /// <summary>
         /// Super position of two pointer
         /// </summary>
-        public static Pointer operator *(Pointer inner, Pointer outter)
+        public static Pointer operator *(Pointer inner, Pointer outer)
         {
-            var radius = outter.Angle / 180 * Math.PI;
+            var radius = outer.Angle / 180d * Math.PI;
             return new Pointer(
-                x: inner.X * Math.Cos(radius) - inner.Y * Math.Sin(radius) + outter.X,
-                y: inner.Y * Math.Cos(radius) + inner.X * Math.Sin(radius) + outter.Y,
-                angle: (outter.Angle + inner.Angle) % 360,
-                flipped: outter.Flipped ^ inner.Flipped
+                x: inner.X * Math.Cos(radius) - inner.Y * Math.Sin(radius) + outer.X,
+                y: inner.Y * Math.Cos(radius) + inner.X * Math.Sin(radius) + outer.Y,
+                angle: (outer.Angle + inner.Angle) % 360d,
+                flipped: outer.Flipped ^ inner.Flipped
             );
         }
+
         /// <summary>
-        /// Get the inner pointer
+        /// Gets the inner pointer
         /// </summary>
-        public static Pointer operator /(Pointer product, Pointer outter)
+        public static Pointer operator /(Pointer product, Pointer outer)
         {
-            return product * new Pointer(x: -outter.X, y: -outter.Y)
-                * new Pointer(angle: -outter.Angle, flipped: outter.Flipped);
+            return product
+                * new Pointer(x: -outer.X, y: -outer.Y, angle: 0d, flipped: false)
+                * new Pointer(x: 0d, y: 0d, angle: -outer.Angle, flipped: outer.Flipped);
+        }
+
+        /// <summary>
+        /// Inner pointer not equal to Outer pointer.
+        /// </summary>
+        /// <param name="inner">The inner.</param>
+        /// <param name="outer">The outer.</param>
+        /// <returns>
+        /// The result of the operator.
+        /// </returns>
+        public static bool operator !=(Pointer inner, Pointer outer)
+        {
+            return !inner.Equals(outer);
+        }
+
+        /// <summary>
+        /// Inner pointer equal to Outer pointer.
+        /// </summary>
+        /// <param name="inner">The inner.</param>
+        /// <param name="outer">The outer.</param>
+        /// <returns>
+        /// The result of the operator.
+        /// </returns>
+        public static bool operator ==(Pointer inner, Pointer outer)
+        {
+            return inner.Equals(outer);
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
+        /// </summary>
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
+        /// <returns>
+        ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (obj is not Pointer) return false;
+            Pointer comp = (Pointer)obj;
+            return
+                Math.Abs(comp.X - X) <= (Math.Max(Math.Abs(comp.X), Math.Abs(X)) * epsilon) &&
+                Math.Abs(comp.Y - Y) <= (Math.Max(Math.Abs(comp.Y), Math.Abs(Y)) * epsilon) &&
+                Math.Abs(comp.Angle - Angle) <= (Math.Max(Math.Abs(comp.Angle), Math.Abs(Angle)) * epsilon) &&
+                comp.Flipped == Flipped &&
+                comp.GetType().Equals(GetType());
+        }
+
+        /// Returns a hash code for this instance.
+        /// </summary>
+        /// <returns>
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
+        /// </returns>
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+
+        /// <summary>
+        /// Converts to string.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="System.String" /> that represents this instance.
+        /// </returns>
+        public override string ToString()
+        {
+            return string.Format(CultureInfo.CurrentCulture,
+                "{{X={0}, Y={1}, Angle={2}, Flipped={3}}}", x, y, angle, flipped);
         }
     }
 }


### PR DESCRIPTION
## Refactoring Pointer Struct

<img src="https://user-images.githubusercontent.com/1063940/111055619-c6d7ab00-84b2-11eb-9d3a-8ba6cf9aa9bf.png" width="400" />

## Features
### Create an empty pointer can now be like this:
```csharp
Pointer pointer = Pointer.Empty;
```

### Pointer equality comparer:
```csharp
Pointer pointerA = new Pointer(1, 2, 45, true);
Pointer pointerB = new Pointer(1, 2, 45, true);

pointerA == pointerB;   // true
```

### Pointer Superposition
```csharp
Pointer pointerA= new Pointer(1, 2, 45, true);
Pointer pointerB = new Pointer(2, 3, 45, true);

var mulPointer = pointerA * pointerB;
var divpointer = mulPointer / pointerB;

divpointer == pointerA;   // true
```
## UnitTests Passed
![image](https://user-images.githubusercontent.com/1063940/111055756-0c48a800-84b4-11eb-9f24-3192bb0638b9.png)

## Adding UnitTest for serializing and deserializing Pointer
```csharp
[Test]
public void Created_Pointer_Can_Be_Serialized_As_Json_And_Deserialized_Back()
{
    Pointer pointerA = new Pointer(1, 2, 45, true);

    // this option is just to make the json formatting pretty
    // and able to convert Pointer struct using custom converter
    var jsonOption = new JsonSerializerOptions { WriteIndented = true };
    jsonOption.Converters.Add(new PointerJsonConverter());

    // first, serialize Pointer as json string
    var json = JsonSerializer.Serialize(pointerA, jsonOption);
    TestContext.WriteLine("Output pointerA as Json");
    TestContext.WriteLine(json);

    // second, deserialize json string back to pointer
    var pointerB = JsonSerializer.Deserialize<Pointer>(json, jsonOption);

    // the result should be equal Pointer
    Assert.AreEqual(pointerA, pointerB);
}
```

The output:
![image](https://user-images.githubusercontent.com/1063940/111055952-0358d600-84b6-11eb-99f5-4d85a0f68b02.png)



