### PR TITLE
Support NET8

### DIFF
--- a/O2DESNet.UnitTests/O2DESNet.UnitTests.csproj
+++ b/O2DESNet.UnitTests/O2DESNet.UnitTests.csproj
@@ -1,20 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+  <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+  <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
+  <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
+  <PackageReference Include="nunit" Version="4.4.0" />
+  <PackageReference Include="NUnit3TestAdapter" Version="5.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="R.NET" Version="1.8.2" />
   </ItemGroup>
 

--- a/O2DESNet.UnitTests/PhaseTracker_Tests.cs
+++ b/O2DESNet.UnitTests/PhaseTracker_Tests.cs
@@ -13,10 +13,12 @@ namespace O2DESNet.UnitTests
             pr.UpdPhase("Busy2", DateTime.MinValue.AddMinutes(2));
             pr.UpdPhase("Idle", DateTime.MinValue.AddMinutes(2.5));
             pr.UpdPhase("Busy2", DateTime.MinValue.AddMinutes(2.9));
-            if (Diff(pr.GetProportion("Idle", DateTime.MinValue.AddMinutes(3)), 1.6 / 3)) Assert.Fail();
-            if (Diff(pr.GetProportion("Busy1", DateTime.MinValue.AddMinutes(3)), 0.8 / 3)) Assert.Fail();
-            if (Diff(pr.GetProportion("Busy2", DateTime.MinValue.AddMinutes(3)), 0.6 / 3)) Assert.Fail();
-            if (Diff(pr.GetProportion("Other", DateTime.MinValue.AddMinutes(3)), 0)) Assert.Fail();
+
+            var checkpoint = DateTime.MinValue.AddMinutes(3);
+            AssertProportion(pr, "Idle", checkpoint, 1.6 / 3);
+            AssertProportion(pr, "Busy1", checkpoint, 0.8 / 3);
+            AssertProportion(pr, "Busy2", checkpoint, 0.6 / 3);
+            AssertProportion(pr, "Other", checkpoint, 0);
         }
 
         [Test]
@@ -27,9 +29,11 @@ namespace O2DESNet.UnitTests
             pr.UpdPhase("Busy2", DateTime.MinValue.AddMinutes(2));
             pr.UpdPhase("Idle", DateTime.MinValue.AddMinutes(2.5));
             pr.UpdPhase("Busy2", DateTime.MinValue.AddMinutes(2.9));
-            if (Diff(pr.GetProportion("Idle", DateTime.MinValue.AddMinutes(3)), 0.6 / 2)) Assert.Fail();
-            if (Diff(pr.GetProportion("Busy1", DateTime.MinValue.AddMinutes(3)), 0.8 / 2)) Assert.Fail();
-            if (Diff(pr.GetProportion("Busy2", DateTime.MinValue.AddMinutes(3)), 0.6 / 2)) Assert.Fail();
+
+            var checkpoint = DateTime.MinValue.AddMinutes(3);
+            AssertProportion(pr, "Idle", checkpoint, 0.6 / 2);
+            AssertProportion(pr, "Busy1", checkpoint, 0.8 / 2);
+            AssertProportion(pr, "Busy2", checkpoint, 0.6 / 2);
         }
 
         [Test]
@@ -41,14 +45,18 @@ namespace O2DESNet.UnitTests
             pr.UpdPhase("Busy2", DateTime.MinValue.AddMinutes(2));
             pr.UpdPhase("Idle", DateTime.MinValue.AddMinutes(2.5));
             pr.UpdPhase("Busy2", DateTime.MinValue.AddMinutes(2.9));
-            if (Diff(pr.GetProportion("Idle", DateTime.MinValue.AddMinutes(3)), 0.4 / 1.5)) Assert.Fail();
-            if (Diff(pr.GetProportion("Busy1", DateTime.MinValue.AddMinutes(3)), 0.5 / 1.5)) Assert.Fail();
-            if (Diff(pr.GetProportion("Busy2", DateTime.MinValue.AddMinutes(3)), 0.6 / 1.5)) Assert.Fail();
+
+            var checkpoint = DateTime.MinValue.AddMinutes(3);
+            AssertProportion(pr, "Idle", checkpoint, 0.4 / 1.5);
+            AssertProportion(pr, "Busy1", checkpoint, 0.5 / 1.5);
+            AssertProportion(pr, "Busy2", checkpoint, 0.6 / 1.5);
         }
 
-        private static bool Diff(double x1, double x2, int decimals = 12)
+        private static void AssertProportion(PhaseTracer tracer, string phase, DateTime checkpoint, double expected)
         {
-            return Math.Round(x1, decimals) != Math.Round(x2, decimals);
+            var actual = tracer.GetProportion(phase, checkpoint);
+            const double tolerance = 1e-9;
+            Assert.That(actual, Is.EqualTo(expected).Within(tolerance), $"{phase} proportion mismatch");
         }
     }
 }

--- a/O2DESNet/O2DESNet.csproj
+++ b/O2DESNet/O2DESNet.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <Version Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0</Version>
     <Version Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</Version>
-    <TargetFramework>netstandard2.1</TargetFramework>
-	  <LangVersion>9.0</LangVersion>
+  <TargetFramework>net8.0</TargetFramework>
+	  <LangVersion>latest</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Li Haobin</Authors>
     <Description>A framework for Object-Oriented Discrete Event Simulation</Description>
@@ -19,8 +19,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MathNet.Numerics" Version="4.8.1" />
-    <PackageReference Include="System.Drawing.Common" Version="4.5.1" />
+    <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Support NET8, which is the latest LTS .NET version. All unit test passed after change.

<img width="1088" height="834" alt="O2DES NET8" src="https://github.com/user-attachments/assets/382bcc84-251d-4ac2-b3e4-3c5ab3f9b586" />
.
<img width="1088" height="834" alt="2ac92c6f1a8f5e75badc2ac0aa20b4a1" src="https://github.com/user-attachments/assets/ed2432ca-1dcd-4c61-bc94-f33c16afb59f" />
